### PR TITLE
Util.java - fixed call that modifies application properties when determining if app is running in debug mode

### DIFF
--- a/FFmpegAndroid/src/main/java/com/github/hiteshsondhi88/libffmpeg/Util.java
+++ b/FFmpegAndroid/src/main/java/com/github/hiteshsondhi88/libffmpeg/Util.java
@@ -13,7 +13,7 @@ import java.io.OutputStream;
 class Util {
 
     static boolean isDebug(Context context) {
-        return (0 != (context.getApplicationContext().getApplicationInfo().flags &= ApplicationInfo.FLAG_DEBUGGABLE));
+        return (0 != (context.getApplicationContext().getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE));
     }
 
     static void close(InputStream inputStream) {


### PR DESCRIPTION
Merged in a fix for this issue:

https://github.com/WritingMinds/ffmpeg-android-java/issues/184